### PR TITLE
Comment out links to non-existent tutorials

### DIFF
--- a/docs/includes/tutorials-list.md
+++ b/docs/includes/tutorials-list.md
@@ -1,15 +1,15 @@
 ## Simple tutorials
 [:material-arrow-right: Make a volume button toggle the flashlight on the lockscreen](tutorials/simple-volume.md)
 
-[:material-arrow-right: Make a floating button to simulate the 'F5' key on a keyboard]()
+<!-- [:material-arrow-right: Make a floating button to simulate the 'F5' key on a keyboard]() -->
 
-[:material-arrow-right: Make the buttons on a gamepad tap the screen for you]()
+<!-- [:material-arrow-right: Make the buttons on a gamepad tap the screen for you]() -->
 
-[:material-arrow-right: Make your side key / power button call a family member if pressed 5 times]()
+<!-- [:material-arrow-right: Make your side key / power button call a family member if pressed 5 times]() -->
 
-## Advanced tutorials
-[:material-arrow-right: Make your volume buttons adjust the flashlight brightness on the lockscreen]()
+<!-- ## Advanced tutorials -->
+<!-- [:material-arrow-right: Make your volume buttons adjust the flashlight brightness on the lockscreen]() -->
 
-[:material-arrow-right: Make a floating button to toggle your home lighting with Home Assistant]()
+<!-- [:material-arrow-right: Make a floating button to toggle your home lighting with Home Assistant]() -->
 
-[:material-arrow-right: Make a custom modifier key on a Bluetooth keyboard]()
+<!-- [:material-arrow-right: Make a custom modifier key on a Bluetooth keyboard]() -->


### PR DESCRIPTION
When I clicked one of the tutorials and nothing happened, I assumed that it was a one-off broken link. Turns out that all of the links except one were just placeholders (which is especially bad because there's nothing to indicate to users that the first link is _not_ broken).

This PR just comments out all of the links except for the working one. If you'd prefer, I'd be happy to edit this PR to instead move them to a list of "future tutorials", where we could even leave a note that contributions would be welcome. If we were to go that route, I think we should de-linkify the tutorials that don't exist yet.