### PR TITLE
Volume tutorial: Refer to an "upcoming" feature, rather than an "experimental" one

### DIFF
--- a/docs/tutorials/simple-volume.md
+++ b/docs/tutorials/simple-volume.md
@@ -36,7 +36,7 @@ You should also see your key map in the list.
 
 Now, lock your device, and with the screen on, long press volume down. Now you can toggle the flashlight on the lockscreen!
 
-You can't use this key map while the screen is off. To make it work with the screen off, you need to use [an experimental feature]().
+You can't use this key map while the screen is off. To make it work with the screen off, you need to use [an upcoming feature](https://github.com/keymapperorg/KeyMapper/issues/1394).
 
 !!! discord "Want to ask for help?"
     If you've already tried troubleshooting and the tutorials aren't enough, come and ask for help in our [support server.](http://keymapper.club)


### PR DESCRIPTION
The "Make a volume button toggle the flashlight on the lockscreen" tutorial includes the following sentence (complete with the broken link).

> You can't use this key map while the screen is off. To make it work with the screen off, you need to use [an experimental feature]().

My best guess is that this is referring to the unmerged [`feature/1394-kernel-remapping`](https://github.com/keymapperorg/KeyMapper/tree/feature/1394-kernel-remapping) branch, and not a feature that has already been merged, but has to be opted into (like I had assumed originally). The edit I made in this PR to change the wording from "experimental" feature to "upcoming" feature and make the link point to https://github.com/keymapperorg/KeyMapper/issues/1394 reflects that assumption, so let me know if it's wrong and I can update the PR.