### PR TITLE
Improve discoverability of the quick start page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ The Key Mapper documentation aims to provide users with a comprehensive guide to
 !!! tip "Get started"
     The best way to get started is with our [Quick Start Guide](quick-start.md).
 
-!!! question "Want a tutorial?"
+!!! question "Want a tutorial for something specific?"
     We've made some [handy tutorials](tutorials-index.md) to help you learn Key Mapper.
 
 !!! discord "Want to ask for help?"

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,9 @@ The Key Mapper documentation aims to provide users with a comprehensive guide to
 
 --8<-- "preamble.md"
 
+!!! tip "Get started"
+    The best way to get started is with our [Quick Start Guide](quick-start.md).
+
 !!! question "Want a tutorial?"
     We've made some [handy tutorials](tutorials-index.md) to help you learn Key Mapper.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_url: https://docs.keymapper.club/
 use_directory_urls: true
 nav:
   - Home: index.md
+  - Quick Start: quick-start.md
   - Troubleshooting: faq.md
   - Tutorials:
       - Make a volume button toggle the flashlight on the lockscreen: tutorials/simple-volume.md


### PR DESCRIPTION
* Adds quick start link to the homepage, in a ["tip" admonition](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#+type:tip)
* Changes the title of the tutorials admonition from "Want a tutorial?" to "Want a tutorial for something specific?"
    * My intention was to help distinguish the concept of the quick start guide (an overview of the whole app) and the tutorials (targeted guides for specific use cases)
* Adds quick start link to the sidebar (the second entry, beneath "home")